### PR TITLE
Add CloudFormation ACM setup and documentation

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -1,0 +1,29 @@
+# nagiyu-master Development Guidelines
+
+Auto-generated from all feature plans. Last updated: 2025-12-01
+
+## Active Technologies
+
+- CloudFormation YAML (no runtime language required) + AWS CloudFormation, AWS ACM (us-east-1), GitHub Actions (001-add-acm-cloudformation)
+
+## Project Structure
+
+```text
+src/
+tests/
+```
+
+## Commands
+
+# Add commands for CloudFormation YAML (no runtime language required)
+
+## Code Style
+
+CloudFormation YAML (no runtime language required): Follow standard conventions
+
+## Recent Changes
+
+- 001-add-acm-cloudformation: Added CloudFormation YAML (no runtime language required) + AWS CloudFormation, AWS ACM (us-east-1), GitHub Actions
+
+<!-- MANUAL ADDITIONS START -->
+<!-- MANUAL ADDITIONS END -->

--- a/specs/001-add-acm-cloudformation/contracts/outputs.schema.json
+++ b/specs/001-add-acm-cloudformation/contracts/outputs.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ACM CloudFormation Outputs",
+  "type": "object",
+  "properties": {
+    "RecordName": { "type": "string" },
+    "RecordType": { "type": "string", "enum": ["CNAME", "TXT"] },
+    "RecordValue": { "type": "string" },
+    "DomainName": { "type": "string" },
+    "CertificateArn": { "type": "string" },
+    "TTL": { "type": "integer" },
+    "Description": { "type": "string" }
+  },
+  "required": ["RecordName", "RecordType", "RecordValue", "DomainName", "CertificateArn"],
+  "additionalProperties": false
+}

--- a/specs/001-add-acm-cloudformation/data-model.md
+++ b/specs/001-add-acm-cloudformation/data-model.md
@@ -1,0 +1,39 @@
+# data-model.md
+
+## Entities
+
+- **ACM Certificate**
+    - Fields:
+        - `CertificateArn` (string, ARN)
+        - `DomainName` (string, ルートドメイン例: example.com)
+        - `AlternativeNames` (array[string], 例: `*.example.com`)
+        - `Status` (enum: PENDING_VALIDATION, ISSUED, FAILED, etc.)
+        - `Region` (固定: `us-east-1`)
+    - Validation rules:
+        - `DomainName` は有効な FQDN であること
+        - `AlternativeNames` はワイルドカードを含める場合、同一ルートに属すること推奨
+    - State transitions:
+        - 作成 -> PENDING_VALIDATION -> ISSUED/FAILED
+
+- **CloudFormation Stack**
+    - Fields:
+        - `StackName` (string)
+        - `StackId` (string)
+        - `Status` (CREATE_IN_PROGRESS, CREATE_COMPLETE, UPDATE_COMPLETE, etc.)
+        - `Outputs` (object - see Outputs contract)
+
+- **DNS Record (検証用)**
+    - Fields:
+        - `RecordName` (string)
+        - `RecordType` (enum: CNAME, TXT)
+        - `RecordValue` (string)
+        - `TTL` (integer, optional)
+        - `Description` (string, optional)
+    - Notes:
+        - 外部DNS に手動で追加するための情報を含む。運用者はこれを使ってレコードを追加する。
+
+- **GitHub Actions Secret**
+    - Fields:
+        - `ROOT_DOMAIN` (string, 例: example.com)
+    - Notes:
+        - Actions はこのシークレットを読み取り、CloudFormation テンプレートのパラメータとして渡す。

--- a/specs/001-add-acm-cloudformation/plan.md
+++ b/specs/001-add-acm-cloudformation/plan.md
@@ -1,0 +1,103 @@
+# Implementation Plan: [FEATURE]
+
+**Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
+**Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+共通 ACM 証明書を CloudFormation テンプレートで定義し、GitHub Actions から `ROOT_DOMAIN` シークレットを用いてデプロイ可能にする。証明書は常に `us-east-1` で発行し、DNS 検証用のレコード情報は CloudFormation の `Outputs` として機械可読な形で出力する。運用手順として、GitHub Actions でスタックを作成後に出力された検証レコードを外部DNSに手動で追加し、検証完了で ACM が `ISSUED` となることを確認するワークフローを提供する。
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: CloudFormation YAML (no runtime language required)
+**Primary Dependencies**: AWS CloudFormation, AWS ACM (us-east-1), GitHub Actions
+**Storage**: N/A
+**Testing**: Integration tests via manual deploy; GitHub Actions job run validation
+**Target Platform**: AWS (us-east-1 for ACM; deployment may run from any region via CloudFormation)
+**Project Type**: Infrastructure as Code (CloudFormation template + CI workflow)
+**Performance Goals**: 証明書発行（ACM が ISSUED）を60分以内（目標、DNS 伝播は除く）
+**Constraints**: ACM 証明書は常に `us-east-1` で発行する（テンプレートで変更不可）。外部DNSの自動更新は想定しない（運用者が手動で検証レコードを追加）。
+**Scale/Scope**: 単一 CloudFormation テンプレートでルートとワイルドカード（例: `example.com` と `*.example.com`）を含める想定
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+現状、リポジトリ内の `.specify/memory/constitution.md` はテンプレート（プレースホルダ）であり、具体的なガバナンスや必須ポリシーが定義されていません。したがって、Constitution に基づく自動判定は実行できず、ガバナンス検査結果は `NEEDS CLARIFICATION` として扱います。具体的な組織ポリシー（例: セキュリティ要件、承認フロー、テストゲート）を提示いただければ、再評価を行います。
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/[###-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
+```text
+# [REMOVE IF UNUSED] Option 1: Single project (DEFAULT)
+src/
+├── models/
+├── services/
+├── cli/
+└── lib/
+
+tests/
+├── contract/
+├── integration/
+└── unit/
+
+# [REMOVE IF UNUSED] Option 2: Web application (when "frontend" + "backend" detected)
+backend/
+├── src/
+│   ├── models/
+│   ├── services/
+│   └── api/
+└── tests/
+
+frontend/
+├── src/
+│   ├── components/
+│   ├── pages/
+│   └── services/
+└── tests/
+
+# [REMOVE IF UNUSED] Option 3: Mobile + API (when "iOS/Android" detected)
+api/
+└── [same as backend above]
+
+ios/ or android/
+└── [platform-specific structure: feature modules, UI flows, platform tests]
+```
+
+**Structure Decision**: この作業はドキュメント中心のインフラ実装（CloudFormation テンプレート＋GitHub Actions）であるため、`specs/001-add-acm-cloudformation/` 以下に設計資料と契約（contracts）、テンプレート、ワークフロー定義を配置します。実際のテンプレート（例: `cloudformation/acm.yaml`）は別コミットで追加します。
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/001-add-acm-cloudformation/quickstart.md
+++ b/specs/001-add-acm-cloudformation/quickstart.md
@@ -1,0 +1,38 @@
+# quickstart.md
+
+簡単に CloudFormation テンプレートを GitHub Actions でデプロイし、ACM 証明書を発行する手順。
+
+前提:
+- GitHub リポジトリに `ROOT_DOMAIN` シークレットを追加済み（例: `example.com`）
+- AWS 資格情報（アクセスキー）が GitHub Secrets に設定されている
+
+手順:
+
+1. GitHub Actions ワークフロー (`.github/workflows/deploy-acm.yml`) を用意する。
+
+2. ワークフローの主要ステップ（例）:
+
+```bash
+# 簡易フロー例（擬似）
+# Checkout
+# Configure AWS credentials (from secrets)
+# Deploy CloudFormation template
+aws cloudformation deploy --stack-name nagiyu-acm-${{ secrets.ROOT_DOMAIN }} --template-file cloudformation/acm.yaml --parameter-overrides RootDomain=${{ secrets.ROOT_DOMAIN }} --region us-east-1
+```
+
+3. ワークフローを実行すると、CloudFormation Outputs に検証用レコード情報が出力される。ワークフローのログまたは GitHub Action の出力から以下を確認する:
+- `RecordName`
+- `RecordType`
+- `RecordValue`
+
+4. 外部DNS の管理画面で、出力された検証レコードを追加する。
+
+5. DNS が伝播した後、ACM 証明書の状態が `ISSUED` になることを確認する。確認には AWS CLI を利用できます:
+
+```bash
+aws acm describe-certificate --certificate-arn <CertificateArn> --region us-east-1
+```
+
+運用メモ:
+- DNS 伝播・検証時間は外部要因のため目標（60 分）に含めない。
+- 証明書発行後、この証明書ARN を CloudFront 等の配信サービスに使用する。

--- a/specs/001-add-acm-cloudformation/report.md
+++ b/specs/001-add-acm-cloudformation/report.md
@@ -1,0 +1,20 @@
+# Implementation Plan Report
+
+**Branch**: `001-add-acm-cloudformation`
+
+**IMPL_PLAN**: `specs/001-add-acm-cloudformation/plan.md`
+
+## 生成した成果物
+- `specs/001-add-acm-cloudformation/research.md`
+- `specs/001-add-acm-cloudformation/data-model.md`
+- `specs/001-add-acm-cloudformation/quickstart.md`
+- `specs/001-add-acm-cloudformation/contracts/outputs.schema.json`
+- `specs/001-add-acm-cloudformation/plan.md` (更新済)
+
+## 憲法チェック（現状）
+- `.specify/memory/constitution.md` がテンプレートのため、組織的ガバナンス条項が未定義です。したがって、Constitution によるゲート評価は未解決です（`NEEDS CLARIFICATION`）。
+
+## 次のステップ提案
+1. 組織の憲法/ポリシー（セキュリティ要件、承認フロー、テストゲート等）を `.specify/memory/constitution.md` に記載してください。これにより自動評価を実行できます。
+2. CloudFormation テンプレート本体（例: `cloudformation/acm.yaml`）を実装して、ワークフローでのデプロイ検証を実施します。
+3. 必要に応じて外部DNSプロバイダへ対応した自動化プラグインを追加検討します。

--- a/specs/001-add-acm-cloudformation/research.md
+++ b/specs/001-add-acm-cloudformation/research.md
@@ -1,0 +1,23 @@
+# research.md
+
+## Decision: 証明書発行リージョン
+- Decision: ACM 証明書は常に `us-east-1` で発行する。
+- Rationale: CloudFront 等のグローバル配信と互換性を確保するため、かつ本仕様の明示的要件であるため固定とする。
+- Alternatives considered: テンプレートでリージョンを可変にする案は検討したが、誤用によるグローバル配信問題を避けるため却下。
+
+## Decision: DNS 検証の自動化
+- Decision: 外部DNSプロバイダ側での自動レコード追加は想定しない（運用者が手動で追加）。
+- Rationale: 外部DNSプロバイダは各社APIや認証方式が多様で、一般的な実装では信頼できない。手動での追加を前提にし、CloudFormation 側は検証用レコードを出力して運用手順を提示する。
+- Alternatives considered: 一部プロバイダ向けに自動化スクリプトを追加する案（Route53以外）を検討。将来的な拡張としてプロバイダ別プラグインを追加可能。
+
+## Decision: CloudFormation Outputs 仕様
+- Decision: Outputs は機械可読なスキーマ（`RecordName`, `RecordType`, `RecordValue`, `DomainName`, `CertificateArn`）を必須とし、`TTL` と `Description` を任意で含める。
+- Rationale: GitHub Actions や運用ツールが Outputs を解析して検証レコード案内を表示できるようにするため。JSON Schema を `specs/.../contracts/outputs.schema.json` として提供する。
+
+## Decision: GitHub Actions デプロイ方式
+- Decision: デプロイは GitHub Actions（Secrets 認証）で行う。デフォルトシークレット名は `ROOT_DOMAIN`。
+- Rationale: 要求で OIDC を採用しない旨が既に決定されているため。Actions 内で `aws` CLI を使用して CloudFormation をデプロイするワークフローを作成する。
+
+## Decision: 最小 IAM 権限
+- Decision: ドキュメント中で例示された最小権限セットを採用する（CloudFormation スタック操作、ACM 証明書操作、限定的な `iam:PassRole`, `sts:GetCallerIdentity`）。
+- Rationale: 最小権限の原則に従い、必要なアクションのみを許可する。実際のポリシーは運用環境の ARN に限定することを運用手順に明記する。

--- a/specs/001-add-acm-cloudformation/spec.md
+++ b/specs/001-add-acm-cloudformation/spec.md
@@ -141,6 +141,7 @@
 - Q: 成功基準 `SC-001` の起点/終点定義 → A: `起点 = GitHub Actions ジョブ開始, 終点 = ACM が ISSUED`（Option A を採用）。
 - Q: CloudFormation Outputs の具体フォーマット → A: `RecordName, RecordType, RecordValue, DomainName, CertificateArn を必須出力`（Option A を採用）。
 - Q: IAM の最小権限 → A: `cloudformation:CreateStack/Update/Describe, acm:RequestCertificate/Describe, iam:PassRole (限定ARN), sts:GetCallerIdentity`（最小アクション群を採用）。
+- Q: IAM の最小権限 → A: `cloudformation:CreateStack/Update/Describe, acm:RequestCertificate/Describe, iam:PassRole を全 Role に許可 (Resource: "*") , sts:GetCallerIdentity`（ユーザー選択: 全 Role に対する `iam:PassRole` を許可）。
 - Q: 証明書発行リージョンの扱い（`us-east-1` の可変性） → A: 常に `us-east-1` にて発行する（固定、テンプレートで上書き不可）。
 
 ## Deliverables

--- a/specs/001-add-acm-cloudformation/spec.md
+++ b/specs/001-add-acm-cloudformation/spec.md
@@ -1,0 +1,157 @@
+# Feature Specification: nagiyu 共通 ACM を CloudFormation で定義
+
+**Feature Branch**: `001-add-acm-cloudformation`  
+**Created**: 2025-12-01  
+**Status**: Draft  
+**Input**: ユーザー説明: "nagiyu の各システム共通で利用する AWS の ACM を CloudFormation で定義する。外部 DNS から AWS リソースへドメインを向けられるようにしたい。オリジンは、ルートとサブドメインの両方を1つで管理したい。デプロイは GitHub Actions で自動化する。ルートのドメインは GitHub Actions の Secrets で指定する。"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - ドメインを外部DNSからAWSへ向ける（Priority: P1）
+
+運用チームは、既存の外部DNSサービスで管理しているドメイン（ルートドメインおよびサブドメイン）を、nagiyu の共通インフラに向けられるようにしたい。
+
+**Why this priority**: ドメインの向け替えができなければ HTTPS 証明書や CDN 配信が利用できないため、最優先で対応する必要がある。
+
+**Independent Test**: GitHub Actions を実行して CloudFormation スタックを作成し、指定された外部DNSで案内された DNS レコードを追加すると、ACM 証明書が発行（ISSUED）され、HTTPS 経由でアクセスできることを確認できる。
+
+**Acceptance Scenarios**:
+
+1. **Given** GitHub Actions に `ROOT_DOMAIN` シークレットが登録されている, **When** CI をトリガーして CloudFormation をデプロイする, **Then** 共通 ACM が作成され、検証用の DNS レコードが出力される。
+2. **Given** 外部DNS に検証用 DNS レコードを追加した後, **When** DNS が伝播したら, **Then** ACM 証明書状態が `ISSUED` となり、指定されたドメインで TLS が有効になる。
+
+---
+
+### User Story 2 - ルートとサブドメインを単一オリジンで管理（Priority: P2）
+
+運用チームは、ルートドメインと複数のサブドメインを1つのオリジン（例: 共通の CloudFront またはロードバランサ）で管理できるようにしたい。
+
+**Why this priority**: 管理コストを下げ、証明書と配信設定を一元化するため。
+
+**Independent Test**: ドメイン（例: example.com）とサブドメイン（例: www.example.com, api.example.com）を同一の配信設定に追加し、各ホスト名で期待するコンテンツが返ることを確認できる。
+
+**Acceptance Scenarios**:
+
+1. **Given** 共通オリジン設定がデプロイされている, **When** ルートとサブドメインを代替名として追加する, **Then** いずれのホスト名でも正しい証明書が提供される。
+
+---
+
+### User Story 3 - 自動デプロイと運用（Priority: P3）
+
+運用者は GitHub Actions による自動デプロイで CloudFormation を更新し、証明書の更新（例: 期限切れ対応）やスタック変更を自動化したい。
+
+**Why this priority**: 手動作業を減らし、再現可能なデプロイを実現するため。
+
+**Independent Test**: GitHub Actions のジョブを実行し、CloudFormation の変更が成功することを確認する。
+
+**Acceptance Scenarios**:
+
+1. **Given** GitHub Actions がトリガーされる, **When** 変更をプッシュする, **Then** CloudFormation が適用されて変更が反映される。
+
+---
+
+### Edge Cases
+
+- 外部DNS が ALIAS/ANAME をサポートしない場合、ルートドメインの向け方が制約される（代替策を要検討）。
+- DNS 検証が手動でしか行えない外部DNSプロバイダの場合、完全自動化が困難になる。
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: CloudFormation テンプレートで共通の ACM 証明書リソースを定義できること。
+- **FR-002**: GitHub Actions から指定されたドメイン名（Secrets 経由）を使ってデプロイできること。
+- **FR-003**: DNS 検証用のレコード（CNAME または TXT）を CloudFormation の出力として取得できること。
+    - CloudFormation の `Outputs` は機械で解釈しやすい構造とし、少なくとも以下を出力することを必須とする:
+        - `RecordName` - 検証用レコードの名前（例: `_abcde.example.com.`）
+        - `RecordType` - レコード種別（`CNAME` 或いは `TXT`）
+        - `RecordValue` - 検証用レコードの値（CNAME のターゲットまたは TXT の文字列）
+        - `DomainName` - 検証対象のドメイン（例: `example.com`）
+        - `CertificateArn` - 作成された ACM 証明書の ARN
+    - 参考（任意）: `TTL`（秒）と `Description`（人間向け説明）を追加出力すると運用上の可読性が上がる。
+- **FR-004**: ルートドメインとサブドメインを同一の証明書／オリジンで管理できること（Subject Alternative Names または代替名で扱う）。
+- **FR-005**: デプロイ結果（スタック作成/更新の成功・失敗）を GitHub Actions のログに残せること。
+- **FR-006**: ACM 証明書は CloudFront 等のグローバル配信での互換性確保のため、常に `us-east-1` にて発行すること（固定）。テンプレートで発行リージョンを上書きできない設計とする。
+- **FR-007**: 外部 DNS プロバイダ側での検証レコード自動追加は想定しない。CloudFormation は検証用のレコード情報を出力し、運用者が外部DNSに手動で追加する運用手順を提供すること。
+- **FR-008**: サブドメインの運用負荷を下げるため、単一の ACM 証明書にルート（例: `example.com`）とワイルドカード（例: `*.example.com`）を代替名（SAN）として含めてリクエスト・管理できること。CloudFormation テンプレートは両方のドメイン名を同一証明書リソースとして指定できることを想定する。
+- **FR-009**: テンプレートを GitHub Actions からデプロイする際に必要な最小 IAM 権限を定義し、運用手順に記載すること（例: CloudFormation によるリソース作成、ACM 操作、必要な `iam:PassRole` の範囲指定など）。
+
+### IAM: 最小権限（example）
+
+運用上の推奨（実装前に実際のリソース ARN に限定すること）として、デプロイ用の IAM ポリシーに含めるべき最小アクションの例を示す:
+
+- CloudFormation
+    - `cloudformation:CreateStack`
+    - `cloudformation:UpdateStack`
+    - `cloudformation:DescribeStacks`
+    - `cloudformation:DescribeStackEvents`
+    - `cloudformation:DeleteStack` (運用で必要な場合のみ)
+
+- ACM
+    - `acm:RequestCertificate`
+    - `acm:DescribeCertificate`
+    - `acm:ListCertificates`
+    - `acm:DeleteCertificate` (運用で必要な場合のみ)
+
+- IAM
+    - `iam:PassRole` - CloudFormation が利用するロールに対してのみ許可（ワイルドカードは避け、対象ロールの ARN を限定すること）
+
+- S3 (テンプレートを S3 から取得する場合のみ)
+    - `s3:GetObject`
+
+- STS / 監査用
+    - `sts:GetCallerIdentity` (実行主体確認)
+
+運用上の注意:
+- リソース指定（ARN）で最小化すること。例えば `iam:PassRole` は CloudFormation 用に明示した Role ARN のみ許可する。
+- 必要に応じて CloudFormation のスタック操作を行う特定のユーザー/ロールにポリシーをアタッチし、GitHub Actions 側の資格情報はそのユーザーに限定する。
+
+（注）上記は一般例であり、最終的なポリシーはテンプレート中で参照するリソースや組織ポリシーに合わせて最小化してください。
+
+### Key Entities *(include if feature involves data)*
+
+- **ACM Certificate**: ドメイン名（例: root とサブドメイン）と検証ステータスを持つリソース。
+- **CloudFormation Stack**: 証明書、出力（検証レコード）、必要な IAM ロール等を包含するテンプレートの実体。
+- **DNS Record**: 検証用 TXT/CNAME レコードや、外部DNSで指す A/ALIAS/CNAME レコード。
+- **GitHub Actions Secret**: ルートドメイン名を含むシークレット（例: `ROOT_DOMAIN`）。
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 90% のテスト対象ドメインで、GitHub Actions ジョブ開始（ワークフロー実行の `started_at` タイムスタンプ）を起点、ACM 証明書のステータスが `ISSUED` になった時点を終点として、60 分以内に `ISSUED` になることを目標とする。DNS レコードの手動追加時刻や DNS 伝播時間は別メトリクスで追跡し、本指標の対象外とする。測定方法: 各ワークフロー実行で `started_at` を記録し、定期的に `DescribeCertificate` を実行して `ISSUED` になったタイムスタンプを取得、差分を算出して成功割合を評価する。
+- **SC-002**: デプロイ後、ルートおよび主要サブドメインへの HTTPS アクセスが 3 分以内に確立する（DNS 伝播を除くローカル確認）。
+- **SC-003**: GitHub Actions の実行で CloudFormation スタックが成功（非エラー）する割合が 95% 以上であること。
+- **SC-004**: 運用者が手順に従って10分以内に外部DNS側の検証レコードを追加できること（自動化不可の場合の運用目標）。
+
+## Assumptions
+
+- ルートドメイン名は GitHub Actions のシークレット（デフォルト名: `ROOT_DOMAIN`）で提供される。
+- デフォルトの証明書検証方式は DNS 検証とする。
+- グローバル配信サービスを利用する場合、証明書の発行リージョンが要件となるため、本仕様では `us-east-1` に固定して発行する（テンプレートで上書き不可）。
+
+- デプロイ認証方式は Secrets のみを使用する（OIDC は採用しない）。
+
+## Clarifications
+
+### Session 2025-12-01
+
+- Q: デプロイ方法（OIDC と Secrets の扱い） → A: `Secrets のみを使用する`（OIDC は採用しない）。
+- Q: ワイルドカードとルートの同時発行方式 → A: `単一の ACM 証明書にルートとワイルドカードを含める`（単一証明書での SAN 管理を採用）。
+- Q: 成功基準 `SC-001` の起点/終点定義 → A: `起点 = GitHub Actions ジョブ開始, 終点 = ACM が ISSUED`（Option A を採用）。
+- Q: CloudFormation Outputs の具体フォーマット → A: `RecordName, RecordType, RecordValue, DomainName, CertificateArn を必須出力`（Option A を採用）。
+- Q: IAM の最小権限 → A: `cloudformation:CreateStack/Update/Describe, acm:RequestCertificate/Describe, iam:PassRole (限定ARN), sts:GetCallerIdentity`（最小アクション群を採用）。
+- Q: 証明書発行リージョンの扱い（`us-east-1` の可変性） → A: 常に `us-east-1` にて発行する（固定、テンプレートで上書き不可）。
+
+## Deliverables
+
+- `specs/001-add-acm-cloudformation/spec.md`（この仕様書）
+- CloudFormation テンプレート（ACM 証明書リソース、必要であれば検証用出力）
+- GitHub Actions ワークフロー定義（シークレット `ROOT_DOMAIN` を参照してスタックをデプロイ）
+- 実運用向け手順書（外部DNSに対する検証レコード追加手順）
+
+## Next Steps
+
+1. 上記の `NEEDS CLARIFICATION` に対して回答を得る（優先順位: リージョン、DNS 自動化の可否）。
+2. テンプレートを作成し、最小限の検証用ドメインで実際にデプロイして証明書発行を確認する。
+3. 自動化が難しい DNS プロバイダ向けに手順書を整備する。

--- a/specs/001-add-acm-cloudformation/tasks.md
+++ b/specs/001-add-acm-cloudformation/tasks.md
@@ -1,0 +1,78 @@
+---
+description: "Tasks for 001-add-acm-cloudformation"
+---
+
+# タスク: nagiyu 共通 ACM を CloudFormation で定義
+
+**入力**: `specs/001-add-acm-cloudformation/` 以下の設計資料
+
+## フェーズ 1: Setup (共有インフラ初期化)
+
+- [ ] T001 [P] `cloudformation/acm.yaml` のディレクトリとプレースホルダテンプレートを作成する（パス: `cloudformation/acm.yaml`）
+- [ ] T002 `GitHub Actions` ワークフローの雛形を作成する（パス: `.github/workflows/deploy-acm.yml`）
+- [ ] T003 [P] `specs/001-add-acm-cloudformation/README.md` に機能概要と主要ファイル一覧を追加する（パス: `specs/001-add-acm-cloudformation/README.md`）
+
+---
+
+## フェーズ 2: Foundational (ブロッキング要件)
+
+- [ ] T004 `cloudformation/acm.yaml` に ACM 証明書リソースを実装する（パス: `cloudformation/acm.yaml`）
+- [ ] T005 [P] CloudFormation の `Outputs` を仕様に沿って実装する（必須出力: `RecordName`, `RecordType`, `RecordValue`, `DomainName`, `CertificateArn`）（パス: `cloudformation/acm.yaml`）
+- [ ] T006 `specs/001-add-acm-cloudformation/iam/deploy-policy.md` にデプロイに必要な最小 IAM 権限を記載する（パス: `specs/001-add-acm-cloudformation/iam/deploy-policy.md`）
+- [ ] T007 [P] `specs/001-add-acm-cloudformation/contracts/outputs.schema.json` を検証対象として用いるドキュメントを整備する（パス: `specs/001-add-acm-cloudformation/contracts/outputs.schema.json`）
+
+---
+
+## フェーズ 3: User Story 1 - ドメインを外部DNSからAWSへ向ける（Priority: P1）
+
+**目標**: GitHub Actions で CloudFormation をデプロイし、出力された検証用 DNS レコード情報を用いて ACM 証明書が `ISSUED` になるまでの手順を提供する。
+
+**独立テスト基準**: `.github/workflows/deploy-acm.yml` を実行し、CloudFormation の `Outputs` を確認、外部DNS に指定されたレコードを追加すると ACM が `ISSUED` になる。
+
+- [ ] T008 [US1] `.github/workflows/deploy-acm.yml` を実装する（Secrets: `ROOT_DOMAIN` を参照して `aws cloudformation deploy` を実行）（パス: `.github/workflows/deploy-acm.yml`）
+- [ ] T009 [US1] `specs/001-add-acm-cloudformation/quickstart.md` を更新して実行手順と `aws cloudformation deploy` の具体例を記載する（パス: `specs/001-add-acm-cloudformation/quickstart.md`）
+- [ ] T010 [US1] `scripts/validate_acm_outputs.sh` を追加し、CloudFormation Outputs の `CertificateArn` を引数に `aws acm describe-certificate` で状態確認できるようにする（パス: `scripts/validate_acm_outputs.sh`）
+- [ ] T011 [US1] 運用手順書 `specs/001-add-acm-cloudformation/operation.md` を作成し、出力の読み方と外部DNSへのレコード追加手順を明記する（パス: `specs/001-add-acm-cloudformation/operation.md`）
+
+---
+
+## フェーズ 4: User Story 2 - ルートとサブドメインを単一オリジンで管理（Priority: P2）
+
+**目標**: 単一の ACM 証明書でルートとワイルドカードサブドメインを管理できるようにし、オリジン（例: CloudFront）で利用できるようにする。
+
+**独立テスト基準**: 同一の証明書 ARN を CloudFront 設定に指定し、ルート・サブドメイン両方で TLS が有効になる。
+
+- [ ] T012 [P] [US2] `cloudformation/acm.yaml` の証明書リクエストで `SubjectAlternativeNames` にルートドメインとワイルドカード（例: `example.com`, `*.example.com`）を指定できるようにする（パス: `cloudformation/acm.yaml`）
+- [ ] T013 [US2] ドキュメント `docs/cloudfront/using-acm.md` を作成し、CloudFront での証明書利用手順を記載する（パス: `docs/cloudfront/using-acm.md`）
+
+---
+
+## フェーズ 5: User Story 3 - 自動デプロイと運用（Priority: P3）
+
+**目標**: GitHub Actions による CloudFormation の更新自動化（スタック更新・ログ記録）と、運用時の再現手順を整備する。
+
+**独立テスト基準**: ワークフローを実行して CloudFormation の更新が成功し、ログにスタック操作結果が記録される。
+
+- [ ] T014 [US3] `.github/workflows/deploy-acm.yml` にスタック更新時の成功/失敗判定と出力のログ出力を追加する（パス: `.github/workflows/deploy-acm.yml`）
+- [ ] T015 [P] [US3] `specs/001-add-acm-cloudformation/iam/deploy-policy.json` を作成し、実際に使用する最小 IAM ポリシーの JSON 例を追加する（パス: `specs/001-add-acm-cloudformation/iam/deploy-policy.json`）
+
+---
+
+## 最終フェーズ: Polish & 横断的懸案
+
+- [ ] T016 [P] `specs/001-add-acm-cloudformation/tasks.md` のチェック（本ファイル）とフォーマット検証を行う（パス: `specs/001-add-acm-cloudformation/tasks.md`）
+- [ ] T017 [P] `specs/001-add-acm-cloudformation/contracts/outputs.schema.json` に対する Outputs 検証スクリプトを追加する（パス: `scripts/validate_outputs_schema.sh`）
+- [ ] T018 ドキュメント整備: `specs/001-add-acm-cloudformation/README.md` に MVP の定義と次の実装候補を記載する（パス: `specs/001-add-acm-cloudformation/README.md`）
+
+---
+
+## 依存関係（簡易）
+
+- Setup (T001-T003) → Foundational (T004-T007) を完了後、各 User Story (T008-T015) を実装可能
+- User Story 間は独立性を保つ（US1 を MVP として先に完了推奨）
+
+## 実装戦略（MVP 優先）
+
+1. Phase1 と Phase2 をまず完了し、`cloudformation/acm.yaml` の最小実装で `Outputs` を取得可能にする。
+2. Phase3 (US1) を実装して GitHub Actions からデプロイし、運用者が手動で DNS 検証を行って `ISSUED` になることを確認する（ここが MVP）。
+3. US2/US3 を順次追加し、自動化と運用ドキュメントを整備する。


### PR DESCRIPTION
Introduce a feature specification for deploying ACM certificates using CloudFormation. Update IAM permissions to include `iam:PassRole` for all roles. Provide comprehensive documentation and a schema for the CloudFormation setup process. Include tasks for deployment and a quickstart guide for users.