### PR TITLE
Update ACM deployment workflow and CloudFormation template

### DIFF
--- a/.github/workflows/deploy-acm.yml
+++ b/.github/workflows/deploy-acm.yml
@@ -2,10 +2,10 @@ name: Deploy ACM
 
 on:
   push:
-    # branches:
-    #   - master
-    #   - develop
-    #   - 'release/**'
+    branches:
+      - master
+      - develop
+      - 'release/**'
     paths:
       - 'cloudformation/acm.yaml'
       - '.github/workflows/deploy-acm.yml'

--- a/.github/workflows/deploy-acm.yml
+++ b/.github/workflows/deploy-acm.yml
@@ -2,10 +2,10 @@ name: Deploy ACM
 
 on:
   push:
-    branches:
-      - master
-      - develop
-      - 'release/**'
+    # branches:
+    #   - master
+    #   - develop
+    #   - 'release/**'
     paths:
       - 'cloudformation/acm.yaml'
       - '.github/workflows/deploy-acm.yml'

--- a/cloudformation/acm.yaml
+++ b/cloudformation/acm.yaml
@@ -36,24 +36,6 @@ Resources:
           Value: nagiyu
 
 Outputs:
-  RecordName:
-    Description: DNS validation record name for the primary domain. Note - For wildcard SANs (e.g., *.example.com), the same validation record typically validates both root and wildcard.
-    Value: !GetAtt NagiyuCertificate.DomainValidationOptions.0.ResourceRecord.Name
-    Export:
-      Name: !Sub "${AWS::StackName}-RecordName"
-
-  RecordType:
-    Description: DNS validation record type for the ACM certificate (CNAME)
-    Value: !GetAtt NagiyuCertificate.DomainValidationOptions.0.ResourceRecord.Type
-    Export:
-      Name: !Sub "${AWS::StackName}-RecordType"
-
-  RecordValue:
-    Description: DNS validation record value for the primary domain
-    Value: !GetAtt NagiyuCertificate.DomainValidationOptions.0.ResourceRecord.Value
-    Export:
-      Name: !Sub "${AWS::StackName}-RecordValue"
-
   DomainName:
     Description: The primary domain name for the certificate
     Value: !Ref RootDomain


### PR DESCRIPTION
Comment out branch triggers in the ACM deployment workflow and remove DNS validation output records from the CloudFormation template to streamline the deployment process. Uncomment branch triggers to restore previous functionality.